### PR TITLE
Fix Virtual Staging AI comment wording

### DIFF
--- a/api/stage.js
+++ b/api/stage.js
@@ -36,7 +36,7 @@ export default async function handler(req, res) {
     const link = await dropbox.sharingCreateSharedLinkWithSettings({ path: fileName });
     const imageUrl = link.result.url.replace("?dl=0", "?raw=1");
 
-    // === Send to VirtualStagingAI ===
+    // === Send to Virtual Staging AI ===
     const vsaiResponse = await fetch("https://api.virtualstagingai.app/v1/render/create", {
       method: "POST",
       headers: {


### PR DESCRIPTION
## Summary
- correct the Virtual Staging AI comment in `api/stage.js` to match product naming

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5837aaf08330bb009365e6a7cc44