### PR TITLE
Ensure checkout and stage endpoints emit CORS headers

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -1,0 +1,5 @@
+export function setCorsHeaders(res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+}

--- a/api/checkout.js
+++ b/api/checkout.js
@@ -1,54 +1,59 @@
- import Stripe from "stripe";
- 
- const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
- 
- export default async function handler(req, res) {
-   if (req.method === "OPTIONS") {
-     res.setHeader("Access-Control-Allow-Origin", "*");
-     res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-     return res.status(200).end();
-   }
- 
-   if (req.method !== "POST") {
-     return res.status(405).json({ error: "Method not allowed" });
-   }
- 
-   try {
+import Stripe from "stripe";
+import { setCorsHeaders } from "./_cors.js";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+export default async function handler(req, res) {
+  setCorsHeaders(res);
+
+  if (req.method === "OPTIONS") {
+    setCorsHeaders(res);
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    setCorsHeaders(res);
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
     const { amount, currency, metadata = {}, customer_email } = req.body;
 
     if (!metadata.job_id || !metadata.dropbox_path || !metadata.image_url) {
+      setCorsHeaders(res);
       return res.status(400).json({ error: "Missing staging metadata" });
     }
- 
-     const session = await stripe.checkout.sessions.create({
-       payment_method_types: ["card"],
-       line_items: [
-         {
-           price_data: {
-             currency: currency,
-             product_data: { name: "Virtual Staging Image" },
-             unit_amount: amount,
-           },
-           quantity: 1,
-         },
-       ],
-       mode: "payment",
-       success_url: `${process.env.WIX_SITE_URL}/thank-you`,
-       cancel_url: `${process.env.WIX_SITE_URL}/cancel`,
+
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ["card"],
+      line_items: [
+        {
+          price_data: {
+            currency: currency,
+            product_data: { name: "Virtual Staging Image" },
+            unit_amount: amount,
+          },
+          quantity: 1,
+        },
+      ],
+      mode: "payment",
+      success_url: `${process.env.WIX_SITE_URL}/thank-you`,
+      cancel_url: `${process.env.WIX_SITE_URL}/cancel`,
       customer_email,
       metadata: {
         job_id: metadata.job_id,
         dropbox_path: metadata.dropbox_path,
         image_url: metadata.image_url,
         room_type: metadata.room_type || "",
-        style: metadata.style || ""
-      }
-     });
+        style: metadata.style || "",
+      },
+    });
  
-     res.status(200).json({ url: session.url });
-   } catch (err) {
-     console.error("Stripe error:", err);
-     res.status(500).json({ error: "Stripe checkout failed" });
-   }
- }
+    setCorsHeaders(res);
+    res.status(200).json({ url: session.url });
+  } catch (err) {
+    console.error("Stripe error:", err);
+    setCorsHeaders(res);
+    res.status(500).json({ error: "Stripe checkout failed" });
+  }
+}

--- a/api/stage.js
+++ b/api/stage.js
@@ -1,61 +1,65 @@
- import fetch from "node-fetch";
- import { Dropbox } from "dropbox";
- 
- export default async function handler(req, res) {
-   if (req.method === "OPTIONS") {
-     res.setHeader("Access-Control-Allow-Origin", "*");
-     res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-     return res.status(200).end();
-   }
- 
-   if (req.method !== "POST") {
-     return res.status(405).json({ error: "Method not allowed" });
-   }
- 
-   try {
-     const { image_base64, room_type, style } = req.body;
- 
-     if (!image_base64 || !room_type || !style) {
-       return res.status(400).json({ error: "Missing required fields" });
-     }
- 
-     // === Upload to Dropbox ===
-     const dropbox = new Dropbox({ accessToken: process.env.DROPBOX_ACCESS_TOKEN });
-     const fileBuffer = Buffer.from(image_base64.split(",")[1], "base64");
-     const jobId = `job_${Date.now()}`;
-     const fileName = `/uploads/${jobId}.jpg`;
- 
-     await dropbox.filesUpload({
-       path: fileName,
-       contents: fileBuffer,
-       mode: "add",
-       autorename: true,
-       mute: false
-     });
- 
-     const link = await dropbox.sharingCreateSharedLinkWithSettings({ path: fileName });
-     const imageUrl = link.result.url.replace("?dl=0", "?raw=1");
- 
-     // === Send to Virtual Staging AI ===
-     const vsaiResponse = await fetch("https://api.virtualstagingai.app/v1/render/create", {
-       method: "POST",
-       headers: {
-         "Authorization": `Api-Key ${process.env.VSAI_API_KEY}`,
-         "Content-Type": "application/json"
-       },
-       body: JSON.stringify({
-         image_url: imageUrl,
-         room_type,
-         style,
-         wait_for_completion: true,
-         add_virtually_staged_watermark: true
-       })
-     });
- 
-     const vsaiResult = await vsaiResponse.json();
- 
-     if (vsaiResult.result_image_url) {
+import fetch from "node-fetch";
+import { Dropbox } from "dropbox";
+import { setCorsHeaders } from "./_cors.js";
+
+export default async function handler(req, res) {
+  setCorsHeaders(res);
+
+  if (req.method === "OPTIONS") {
+    setCorsHeaders(res);
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    setCorsHeaders(res);
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const { image_base64, room_type, style } = req.body;
+
+    if (!image_base64 || !room_type || !style) {
+      setCorsHeaders(res);
+      return res.status(400).json({ error: "Missing required fields" });
+    }
+
+    // === Upload to Dropbox ===
+    const dropbox = new Dropbox({ accessToken: process.env.DROPBOX_ACCESS_TOKEN });
+    const fileBuffer = Buffer.from(image_base64.split(",")[1], "base64");
+    const jobId = `job_${Date.now()}`;
+    const fileName = `/uploads/${jobId}.jpg`;
+
+    await dropbox.filesUpload({
+      path: fileName,
+      contents: fileBuffer,
+      mode: "add",
+      autorename: true,
+      mute: false,
+    });
+
+    const link = await dropbox.sharingCreateSharedLinkWithSettings({ path: fileName });
+    const imageUrl = link.result.url.replace("?dl=0", "?raw=1");
+
+    // === Send to Virtual Staging AI ===
+    const vsaiResponse = await fetch("https://api.virtualstagingai.app/v1/render/create", {
+      method: "POST",
+      headers: {
+        "Authorization": `Api-Key ${process.env.VSAI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        image_url: imageUrl,
+        room_type,
+        style,
+        wait_for_completion: true,
+        add_virtually_staged_watermark: true,
+      }),
+    });
+
+    const vsaiResult = await vsaiResponse.json();
+
+    if (vsaiResult.result_image_url) {
+      setCorsHeaders(res);
       return res.status(200).json({
         preview_url: vsaiResult.result_image_url,
         job_id: jobId,
@@ -64,11 +68,13 @@
         room_type,
         style
       });
-     } else {
-       return res.status(500).json({ error: "Staging failed", details: vsaiResult });
-     }
-   } catch (error) {
-     console.error("Server error:", error);
-     return res.status(500).json({ error: "Server error", details: error.message });
-   }
- }
+    } else {
+      setCorsHeaders(res);
+      return res.status(500).json({ error: "Staging failed", details: vsaiResult });
+    }
+  } catch (error) {
+    console.error("Server error:", error);
+    setCorsHeaders(res);
+    return res.status(500).json({ error: "Server error", details: error.message });
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to configure the Access-Control headers shared by the API routes
- call the helper at the top of the checkout and stage handlers and before returning any response

## Testing
- not run (manual verification requires a browser client)

------
https://chatgpt.com/codex/tasks/task_e_68dd9685cd508330868abf699b7b90c2