### PR TITLE
Add Virtual Staging API proxy endpoints for Wix

### DIFF
--- a/api/_utils/http.js
+++ b/api/_utils/http.js
@@ -1,0 +1,32 @@
+export function applyCors(res, methods = ["GET", "POST", "OPTIONS"]) {
+  if (typeof res.setHeader === "function") {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", methods.join(", "));
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  }
+}
+
+export function handleOptions(req, res) {
+  if (req.method === "OPTIONS") {
+    res.status(200).end();
+    return true;
+  }
+
+  return false;
+}
+
+export function methodNotAllowed(res) {
+  return res.status(405).json({ error: "Method not allowed" });
+}
+
+export function normaliseErrorPayload(payload, fallbackMessage = "VSAI request failed") {
+  if (payload && typeof payload === "object") {
+    return payload;
+  }
+
+  if (payload === undefined || payload === null) {
+    return { error: fallbackMessage };
+  }
+
+  return { error: fallbackMessage, details: payload };
+}

--- a/api/_utils/vsai.js
+++ b/api/_utils/vsai.js
@@ -1,0 +1,55 @@
+let fetchPromise;
+async function loadFetch() {
+  if (typeof fetch === "function") {
+    return (...args) => fetch(...args);
+  }
+
+  if (!fetchPromise) {
+    fetchPromise = import("node-fetch").then((mod) => mod.default);
+  }
+
+  return fetchPromise;
+}
+
+export function createVsaiRequest({ fetchImpl } = {}) {
+  let cachedFetch = fetchImpl;
+
+  return async function vsaiRequest({ url, method = "GET", body, headers = {}, apiKey }) {
+    const requestFetch = cachedFetch ?? (cachedFetch = await loadFetch());
+
+    const requestHeaders = {
+      Authorization: `Api-Key ${apiKey}`,
+      ...headers,
+    };
+
+    const init = {
+      method,
+      headers: requestHeaders,
+    };
+
+    if (body !== undefined) {
+      init.body = typeof body === "string" ? body : JSON.stringify(body);
+      if (!("Content-Type" in requestHeaders)) {
+        requestHeaders["Content-Type"] = "application/json";
+      }
+    }
+
+    const response = await requestFetch(url, init);
+    const raw = await response.text();
+    let data = null;
+
+    if (raw) {
+      try {
+        data = JSON.parse(raw);
+      } catch {
+        data = raw;
+      }
+    }
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      data,
+    };
+  };
+}

--- a/api/checkout.js
+++ b/api/checkout.js
@@ -1,54 +1,112 @@
- import Stripe from "stripe";
- 
- const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
- 
- export default async function handler(req, res) {
-   if (req.method === "OPTIONS") {
-     res.setHeader("Access-Control-Allow-Origin", "*");
-     res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-     return res.status(200).end();
-   }
- 
-   if (req.method !== "POST") {
-     return res.status(405).json({ error: "Method not allowed" });
-   }
- 
-   try {
-    const { amount, currency, metadata = {}, customer_email } = req.body;
+function applyCors(res) {
+  if (typeof res.setHeader === "function") {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  }
+}
 
-    if (!metadata.job_id || !metadata.dropbox_path || !metadata.image_url) {
-      return res.status(400).json({ error: "Missing staging metadata" });
+function normaliseSiteUrl(siteUrl) {
+  if (!siteUrl) {
+    return "";
+  }
+
+  return siteUrl.endsWith("/") ? siteUrl.slice(0, -1) : siteUrl;
+}
+
+let stripeModulePromise;
+async function loadStripe() {
+  if (!stripeModulePromise) {
+    stripeModulePromise = import("stripe").then((mod) => mod.default ?? mod);
+  }
+
+  return stripeModulePromise;
+}
+
+export function createCheckoutHandler({ stripeClient, stripeFactory } = {}) {
+  const getStripeClient = async () => {
+    if (stripeClient) {
+      return stripeClient;
     }
- 
-     const session = await stripe.checkout.sessions.create({
-       payment_method_types: ["card"],
-       line_items: [
-         {
-           price_data: {
-             currency: currency,
-             product_data: { name: "Virtual Staging Image" },
-             unit_amount: amount,
-           },
-           quantity: 1,
-         },
-       ],
-       mode: "payment",
-       success_url: `${process.env.WIX_SITE_URL}/thank-you`,
-       cancel_url: `${process.env.WIX_SITE_URL}/cancel`,
-      customer_email,
-      metadata: {
-        job_id: metadata.job_id,
-        dropbox_path: metadata.dropbox_path,
-        image_url: metadata.image_url,
-        room_type: metadata.room_type || "",
-        style: metadata.style || ""
-      }
-     });
- 
-     res.status(200).json({ url: session.url });
-   } catch (err) {
-     console.error("Stripe error:", err);
-     res.status(500).json({ error: "Stripe checkout failed" });
-   }
- }
+
+    const factory =
+      stripeFactory ??
+      (async () => {
+        const StripeCtor = await loadStripe();
+        return new StripeCtor(process.env.STRIPE_SECRET_KEY, {
+          apiVersion: "2023-10-16",
+        });
+      });
+
+    return factory();
+  };
+
+  return async function handler(req, res) {
+    applyCors(res);
+
+    if (req.method === "OPTIONS") {
+      return res.status(200).end();
+    }
+
+    if (req.method !== "POST") {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+
+    const { amount, currency, metadata = {}, customer_email } = req.body || {};
+
+    if (
+      typeof amount !== "number" ||
+      !Number.isFinite(amount) ||
+      amount <= 0 ||
+      typeof currency !== "string" ||
+      currency.trim() === ""
+    ) {
+      return res.status(400).json({ error: "Invalid request payload" });
+    }
+
+    const siteUrl = normaliseSiteUrl(process.env.WIX_SITE_URL);
+    if (!siteUrl) {
+      return res.status(500).json({ error: "Missing Wix site URL" });
+    }
+
+    let client;
+    try {
+      client = await Promise.resolve(getStripeClient());
+    } catch (error) {
+      console.error("Stripe client error:", error);
+      return res.status(500).json({ error: "Stripe client unavailable" });
+    }
+
+    try {
+      const session = await client.checkout.sessions.create({
+        payment_method_types: ["card"],
+        line_items: [
+          {
+            price_data: {
+              currency,
+              product_data: { name: "Virtual Staging Image" },
+              unit_amount: amount,
+            },
+            quantity: 1,
+          },
+        ],
+        mode: "payment",
+        success_url: `${siteUrl}/thank-you`,
+        cancel_url: `${siteUrl}/cancel`,
+        customer_email,
+        metadata:
+          metadata && typeof metadata === "object" && !Array.isArray(metadata)
+            ? metadata
+            : {},
+      });
+
+      return res.status(200).json({ url: session.url });
+    } catch (error) {
+      console.error("Stripe error:", error);
+      return res.status(500).json({ error: "Stripe checkout failed" });
+    }
+  };
+}
+
+const handler = createCheckoutHandler();
+export default handler;

--- a/api/options.js
+++ b/api/options.js
@@ -1,0 +1,47 @@
+import { applyCors, handleOptions, methodNotAllowed, normaliseErrorPayload } from "./_utils/http.js";
+import { createVsaiRequest } from "./_utils/vsai.js";
+
+export function createOptionsHandler({ fetchImpl } = {}) {
+  const vsaiRequest = createVsaiRequest({ fetchImpl });
+
+  return async function handler(req, res) {
+    applyCors(res, ["GET", "OPTIONS"]);
+
+    if (handleOptions(req, res)) {
+      return;
+    }
+
+    if (req.method !== "GET") {
+      methodNotAllowed(res);
+      return;
+    }
+
+    const apiKey = process.env.VSAI_API_KEY;
+    if (!apiKey) {
+      res.status(500).json({ error: "Missing Virtual Staging API key" });
+      return;
+    }
+
+    try {
+      const response = await vsaiRequest({
+        url: "https://api.virtualstagingai.app/v1/options",
+        apiKey,
+      });
+
+      if (!response.ok) {
+        res
+          .status(response.status)
+          .json(normaliseErrorPayload(response.data));
+        return;
+      }
+
+      res.status(response.status).json(response.data ?? {});
+    } catch (error) {
+      console.error("VSAI options error:", error);
+      res.status(502).json({ error: "Failed to contact Virtual Staging API" });
+    }
+  };
+}
+
+const handler = createOptionsHandler();
+export default handler;

--- a/api/ping.js
+++ b/api/ping.js
@@ -1,0 +1,47 @@
+import { applyCors, handleOptions, methodNotAllowed, normaliseErrorPayload } from "./_utils/http.js";
+import { createVsaiRequest } from "./_utils/vsai.js";
+
+export function createPingHandler({ fetchImpl } = {}) {
+  const vsaiRequest = createVsaiRequest({ fetchImpl });
+
+  return async function handler(req, res) {
+    applyCors(res, ["GET", "OPTIONS"]);
+
+    if (handleOptions(req, res)) {
+      return;
+    }
+
+    if (req.method !== "GET") {
+      methodNotAllowed(res);
+      return;
+    }
+
+    const apiKey = process.env.VSAI_API_KEY;
+    if (!apiKey) {
+      res.status(500).json({ error: "Missing Virtual Staging API key" });
+      return;
+    }
+
+    try {
+      const response = await vsaiRequest({
+        url: "https://api.virtualstagingai.app/v1/ping",
+        apiKey,
+      });
+
+      if (!response.ok) {
+        res
+          .status(response.status)
+          .json(normaliseErrorPayload(response.data));
+        return;
+      }
+
+      res.status(response.status).json(response.data ?? {});
+    } catch (error) {
+      console.error("VSAI ping error:", error);
+      res.status(502).json({ error: "Failed to contact Virtual Staging API" });
+    }
+  };
+}
+
+const handler = createPingHandler();
+export default handler;

--- a/api/render-create-variation.js
+++ b/api/render-create-variation.js
@@ -1,0 +1,60 @@
+import { applyCors, handleOptions, methodNotAllowed, normaliseErrorPayload } from "./_utils/http.js";
+import { createVsaiRequest } from "./_utils/vsai.js";
+
+export function createRenderVariationHandler({ fetchImpl } = {}) {
+  const vsaiRequest = createVsaiRequest({ fetchImpl });
+
+  return async function handler(req, res) {
+    applyCors(res, ["POST", "OPTIONS"]);
+
+    if (handleOptions(req, res)) {
+      return;
+    }
+
+    if (req.method !== "POST") {
+      methodNotAllowed(res);
+      return;
+    }
+
+    const apiKey = process.env.VSAI_API_KEY;
+    if (!apiKey) {
+      res.status(500).json({ error: "Missing Virtual Staging API key" });
+      return;
+    }
+
+    const renderId = req.query?.render_id || req.query?.renderId;
+    if (!renderId) {
+      res.status(400).json({ error: "Missing render_id" });
+      return;
+    }
+
+    const payload = req.body && typeof req.body === "object" ? req.body : {};
+
+    const url = new URL("https://api.virtualstagingai.app/v1/render/create-variation");
+    url.searchParams.set("render_id", renderId);
+
+    try {
+      const response = await vsaiRequest({
+        url: url.toString(),
+        method: "POST",
+        body: payload,
+        apiKey,
+      });
+
+      if (!response.ok) {
+        res
+          .status(response.status)
+          .json(normaliseErrorPayload(response.data));
+        return;
+      }
+
+      res.status(response.status).json(response.data ?? {});
+    } catch (error) {
+      console.error("VSAI render variation error:", error);
+      res.status(502).json({ error: "Failed to contact Virtual Staging API" });
+    }
+  };
+}
+
+const handler = createRenderVariationHandler();
+export default handler;

--- a/api/render-create.js
+++ b/api/render-create.js
@@ -1,0 +1,51 @@
+import { applyCors, handleOptions, methodNotAllowed, normaliseErrorPayload } from "./_utils/http.js";
+import { createVsaiRequest } from "./_utils/vsai.js";
+
+export function createRenderCreateHandler({ fetchImpl } = {}) {
+  const vsaiRequest = createVsaiRequest({ fetchImpl });
+
+  return async function handler(req, res) {
+    applyCors(res, ["POST", "OPTIONS"]);
+
+    if (handleOptions(req, res)) {
+      return;
+    }
+
+    if (req.method !== "POST") {
+      methodNotAllowed(res);
+      return;
+    }
+
+    const apiKey = process.env.VSAI_API_KEY;
+    if (!apiKey) {
+      res.status(500).json({ error: "Missing Virtual Staging API key" });
+      return;
+    }
+
+    const payload = req.body && typeof req.body === "object" ? req.body : {};
+
+    try {
+      const response = await vsaiRequest({
+        url: "https://api.virtualstagingai.app/v1/render/create",
+        method: "POST",
+        body: payload,
+        apiKey,
+      });
+
+      if (!response.ok) {
+        res
+          .status(response.status)
+          .json(normaliseErrorPayload(response.data));
+        return;
+      }
+
+      res.status(response.status).json(response.data ?? {});
+    } catch (error) {
+      console.error("VSAI render/create error:", error);
+      res.status(502).json({ error: "Failed to contact Virtual Staging API" });
+    }
+  };
+}
+
+const handler = createRenderCreateHandler();
+export default handler;

--- a/api/render.js
+++ b/api/render.js
@@ -1,0 +1,56 @@
+import { applyCors, handleOptions, methodNotAllowed, normaliseErrorPayload } from "./_utils/http.js";
+import { createVsaiRequest } from "./_utils/vsai.js";
+
+export function createRenderHandler({ fetchImpl } = {}) {
+  const vsaiRequest = createVsaiRequest({ fetchImpl });
+
+  return async function handler(req, res) {
+    applyCors(res, ["GET", "OPTIONS"]);
+
+    if (handleOptions(req, res)) {
+      return;
+    }
+
+    if (req.method !== "GET") {
+      methodNotAllowed(res);
+      return;
+    }
+
+    const apiKey = process.env.VSAI_API_KEY;
+    if (!apiKey) {
+      res.status(500).json({ error: "Missing Virtual Staging API key" });
+      return;
+    }
+
+    const renderId = req.query?.render_id || req.query?.renderId;
+    if (!renderId) {
+      res.status(400).json({ error: "Missing render_id" });
+      return;
+    }
+
+    const url = new URL("https://api.virtualstagingai.app/v1/render");
+    url.searchParams.set("render_id", renderId);
+
+    try {
+      const response = await vsaiRequest({
+        url: url.toString(),
+        apiKey,
+      });
+
+      if (!response.ok) {
+        res
+          .status(response.status)
+          .json(normaliseErrorPayload(response.data));
+        return;
+      }
+
+      res.status(response.status).json(response.data ?? {});
+    } catch (error) {
+      console.error("VSAI render lookup error:", error);
+      res.status(502).json({ error: "Failed to contact Virtual Staging API" });
+    }
+  };
+}
+
+const handler = createRenderHandler();
+export default handler;

--- a/api/stage.js
+++ b/api/stage.js
@@ -1,74 +1,186 @@
- import fetch from "node-fetch";
- import { Dropbox } from "dropbox";
- 
- export default async function handler(req, res) {
-   if (req.method === "OPTIONS") {
-     res.setHeader("Access-Control-Allow-Origin", "*");
-     res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-     return res.status(200).end();
-   }
- 
-   if (req.method !== "POST") {
-     return res.status(405).json({ error: "Method not allowed" });
-   }
- 
-   try {
-     const { image_base64, room_type, style } = req.body;
- 
-     if (!image_base64 || !room_type || !style) {
-       return res.status(400).json({ error: "Missing required fields" });
-     }
- 
-     // === Upload to Dropbox ===
-     const dropbox = new Dropbox({ accessToken: process.env.DROPBOX_ACCESS_TOKEN });
-     const fileBuffer = Buffer.from(image_base64.split(",")[1], "base64");
-     const jobId = `job_${Date.now()}`;
-     const fileName = `/uploads/${jobId}.jpg`;
- 
-     await dropbox.filesUpload({
-       path: fileName,
-       contents: fileBuffer,
-       mode: "add",
-       autorename: true,
-       mute: false
-     });
- 
-     const link = await dropbox.sharingCreateSharedLinkWithSettings({ path: fileName });
-     const imageUrl = link.result.url.replace("?dl=0", "?raw=1");
- 
-     // === Send to Virtual Staging AI ===
-     const vsaiResponse = await fetch("https://api.virtualstagingai.app/v1/render/create", {
-       method: "POST",
-       headers: {
-         "Authorization": `Api-Key ${process.env.VSAI_API_KEY}`,
-         "Content-Type": "application/json"
-       },
-       body: JSON.stringify({
-         image_url: imageUrl,
-         room_type,
-         style,
-         wait_for_completion: true,
-         add_virtually_staged_watermark: true
-       })
-     });
- 
-     const vsaiResult = await vsaiResponse.json();
- 
-     if (vsaiResult.result_image_url) {
+function applyCors(res) {
+  if (typeof res.setHeader === "function") {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  }
+}
+
+let fetchPromise;
+async function resolveFetch(providedFetch) {
+  if (providedFetch) {
+    return providedFetch;
+  }
+
+  if (typeof fetch === "function") {
+    return (...args) => fetch(...args);
+  }
+
+  if (!fetchPromise) {
+    fetchPromise = import("node-fetch").then((mod) => mod.default);
+  }
+
+  return fetchPromise;
+}
+
+let dropboxCtorPromise;
+async function resolveDropboxFactory(factory, options) {
+  if (factory) {
+    return Promise.resolve(factory(options));
+  }
+
+  if (!dropboxCtorPromise) {
+    dropboxCtorPromise = import("dropbox").then((mod) => mod.Dropbox);
+  }
+
+  const Dropbox = await dropboxCtorPromise;
+  return new Dropbox(options);
+}
+
+function parseBase64Image(payload) {
+  if (typeof payload !== "string" || payload.trim() === "") {
+    return null;
+  }
+
+  const [, base64Part = ""] = payload.split(",");
+  const cleanBase64 = base64Part.trim();
+
+  if (cleanBase64 === "") {
+    return null;
+  }
+
+  try {
+    const buffer = Buffer.from(cleanBase64, "base64");
+    if (!buffer || buffer.length === 0) {
+      return null;
+    }
+
+    return buffer;
+  } catch (error) {
+    return null;
+  }
+}
+
+function toRawDropboxUrl(url) {
+  if (typeof url !== "string") {
+    return "";
+  }
+
+  if (url.includes("?raw=1")) {
+    return url;
+  }
+
+  if (url.includes("?dl=0")) {
+    return url.replace("?dl=0", "?raw=1");
+  }
+
+  return `${url}${url.includes("?") ? "&" : "?"}raw=1`;
+}
+
+export function createStageHandler({
+  fetchImpl,
+  dropboxFactory,
+  idGenerator = () => Date.now(),
+} = {}) {
+  let cachedFetch = fetchImpl;
+
+  return async function handler(req, res) {
+    applyCors(res);
+
+    if (req.method === "OPTIONS") {
+      return res.status(200).end();
+    }
+
+    if (req.method !== "POST") {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+
+    const { image_base64, room_type, style } = req.body || {};
+
+    if (!image_base64 || !room_type || !style) {
+      return res.status(400).json({ error: "Missing required fields" });
+    }
+
+    const imageBuffer = parseBase64Image(image_base64);
+    if (!imageBuffer) {
+      return res.status(400).json({ error: "Invalid image payload" });
+    }
+
+    if (!process.env.DROPBOX_ACCESS_TOKEN) {
+      return res.status(500).json({ error: "Missing Dropbox access token" });
+    }
+
+    if (!process.env.VSAI_API_KEY) {
+      return res
+        .status(500)
+        .json({ error: "Missing Virtual Staging API key" });
+    }
+
+    try {
+      const dropbox = await resolveDropboxFactory(dropboxFactory, {
+        accessToken: process.env.DROPBOX_ACCESS_TOKEN,
+      });
+
+      const jobId = `job_${idGenerator()}`;
+      const filePath = `/uploads/${jobId}.jpg`;
+
+      await dropbox.filesUpload({
+        path: filePath,
+        contents: imageBuffer,
+        mode: "add",
+        autorename: true,
+        mute: false,
+      });
+
+      const link = await dropbox.sharingCreateSharedLinkWithSettings({
+        path: filePath,
+      });
+
+      const originalImageUrl = toRawDropboxUrl(link.result.url);
+
+      const activeFetch =
+        cachedFetch ?? (cachedFetch = await resolveFetch(fetchImpl));
+
+      const vsaiResponse = await activeFetch(
+        "https://api.virtualstagingai.app/v1/render/create",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Api-Key ${process.env.VSAI_API_KEY}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            image_url: originalImageUrl,
+            room_type,
+            style,
+            wait_for_completion: true,
+            add_virtually_staged_watermark: true,
+          }),
+        },
+      );
+
+      const vsaiResult = await vsaiResponse.json();
+
+      if (!vsaiResponse.ok || !vsaiResult?.result_image_url) {
+        return res
+          .status(500)
+          .json({ error: "Staging failed", details: vsaiResult });
+      }
+
       return res.status(200).json({
         preview_url: vsaiResult.result_image_url,
         job_id: jobId,
-        dropbox_path: fileName,
-        image_url: imageUrl,
+        dropbox_path: filePath,
+        image_url: originalImageUrl,
         room_type,
-        style
+        style,
       });
-     } else {
-       return res.status(500).json({ error: "Staging failed", details: vsaiResult });
-     }
-   } catch (error) {
-     console.error("Server error:", error);
-     return res.status(500).json({ error: "Server error", details: error.message });
-   }
- }
+    } catch (error) {
+      console.error("Server error:", error);
+      return res.status(500).json({ error: "Server error", details: error.message });
+    }
+  };
+}
+
+const handler = createStageHandler();
+export default handler;

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -1,8 +1,9 @@
-export function createMockReq({ method = "GET", body = {}, headers = {} } = {}) {
+export function createMockReq({ method = "GET", body = {}, headers = {}, query = {} } = {}) {
   return {
     method,
     body,
     headers,
+    query,
   };
 }
 

--- a/tests/vsai-handlers.test.js
+++ b/tests/vsai-handlers.test.js
@@ -1,0 +1,293 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createPingHandler } from "../api/ping.js";
+import { createRenderCreateHandler } from "../api/render-create.js";
+import { createRenderHandler } from "../api/render.js";
+import { createRenderVariationHandler } from "../api/render-create-variation.js";
+import { createOptionsHandler } from "../api/options.js";
+import { createMockReq, createMockRes } from "./test-utils.js";
+
+describe("VSAI proxy handlers", () => {
+  describe("ping", () => {
+    it("rejects non-GET methods", async () => {
+      const handler = createPingHandler();
+      const req = createMockReq({ method: "POST" });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 405);
+      assert.deepEqual(res.body, { error: "Method not allowed" });
+    });
+
+    it("requires an API key", async () => {
+      let called = false;
+      const handler = createPingHandler({
+        fetchImpl: async () => {
+          called = true;
+          return {
+            ok: true,
+            status: 200,
+            async text() {
+              return "{}";
+            },
+          };
+        },
+      });
+
+      const req = createMockReq({ method: "GET" });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 500);
+      assert.deepEqual(res.body, { error: "Missing Virtual Staging API key" });
+      assert.equal(called, false);
+    });
+
+    it("returns the upstream response when successful", async () => {
+      process.env.VSAI_API_KEY = "test-key";
+      const handler = createPingHandler({
+        fetchImpl: async (url, options) => {
+          assert.equal(url, "https://api.virtualstagingai.app/v1/ping");
+          assert.equal(options.method, "GET");
+          assert.equal(options.headers.Authorization, "Api-Key test-key");
+
+          return {
+            ok: true,
+            status: 200,
+            async text() {
+              return JSON.stringify({ userObj: { email: "user@example.com" } });
+            },
+          };
+        },
+      });
+
+      const req = createMockReq({ method: "GET" });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.body, { userObj: { email: "user@example.com" } });
+
+      delete process.env.VSAI_API_KEY;
+    });
+  });
+
+  describe("render/create", () => {
+    it("rejects non-POST methods", async () => {
+      const handler = createRenderCreateHandler();
+      const req = createMockReq({ method: "GET" });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 405);
+      assert.deepEqual(res.body, { error: "Method not allowed" });
+    });
+
+    it("requires an API key", async () => {
+      let called = false;
+      const handler = createRenderCreateHandler({
+        fetchImpl: async () => {
+          called = true;
+          return {
+            ok: true,
+            status: 200,
+            async text() {
+              return "{}";
+            },
+          };
+        },
+      });
+
+      const req = createMockReq({ method: "POST", body: {} });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 500);
+      assert.deepEqual(res.body, { error: "Missing Virtual Staging API key" });
+      assert.equal(called, false);
+    });
+
+    it("forwards payloads to the VSAI API", async () => {
+      process.env.VSAI_API_KEY = "render-key";
+
+      const handler = createRenderCreateHandler({
+        fetchImpl: async (url, options) => {
+          assert.equal(url, "https://api.virtualstagingai.app/v1/render/create");
+          assert.equal(options.method, "POST");
+          assert.equal(options.headers.Authorization, "Api-Key render-key");
+          assert.equal(options.headers["Content-Type"], "application/json");
+
+          const body = JSON.parse(options.body);
+          assert.deepEqual(body, {
+            image_url: "https://example.com/image.jpg",
+            room_type: "living",
+            style: "modern",
+          });
+
+          return {
+            ok: true,
+            status: 200,
+            async text() {
+              return JSON.stringify({ render_id: "abc" });
+            },
+          };
+        },
+      });
+
+      const req = createMockReq({
+        method: "POST",
+        body: {
+          image_url: "https://example.com/image.jpg",
+          room_type: "living",
+          style: "modern",
+        },
+      });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.body, { render_id: "abc" });
+
+      delete process.env.VSAI_API_KEY;
+    });
+  });
+
+  describe("render lookup", () => {
+    it("requires a render_id", async () => {
+      process.env.VSAI_API_KEY = "lookup-key";
+      const handler = createRenderHandler();
+      const req = createMockReq({ method: "GET", query: {} });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 400);
+      assert.deepEqual(res.body, { error: "Missing render_id" });
+
+      delete process.env.VSAI_API_KEY;
+    });
+
+    it("proxies requests to the render endpoint", async () => {
+      process.env.VSAI_API_KEY = "lookup-key";
+      const handler = createRenderHandler({
+        fetchImpl: async (url, options) => {
+          assert.equal(url, "https://api.virtualstagingai.app/v1/render?render_id=xyz");
+          assert.equal(options.method, "GET");
+          assert.equal(options.headers.Authorization, "Api-Key lookup-key");
+
+          return {
+            ok: true,
+            status: 200,
+            async text() {
+              return JSON.stringify({ render_id: "xyz", status: "done" });
+            },
+          };
+        },
+      });
+
+      const req = createMockReq({ method: "GET", query: { render_id: "xyz" } });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.body, { render_id: "xyz", status: "done" });
+
+      delete process.env.VSAI_API_KEY;
+    });
+  });
+
+  describe("render variation", () => {
+    it("requires a render_id", async () => {
+      process.env.VSAI_API_KEY = "variation-key";
+      const handler = createRenderVariationHandler();
+      const req = createMockReq({ method: "POST", query: {} });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 400);
+      assert.deepEqual(res.body, { error: "Missing render_id" });
+
+      delete process.env.VSAI_API_KEY;
+    });
+
+    it("sends the variation request upstream", async () => {
+      process.env.VSAI_API_KEY = "variation-key";
+      const handler = createRenderVariationHandler({
+        fetchImpl: async (url, options) => {
+          assert.equal(
+            url,
+            "https://api.virtualstagingai.app/v1/render/create-variation?render_id=xyz",
+          );
+          assert.equal(options.method, "POST");
+          assert.equal(options.headers.Authorization, "Api-Key variation-key");
+          assert.equal(options.headers["Content-Type"], "application/json");
+
+          const body = JSON.parse(options.body);
+          assert.deepEqual(body, { wait_for_completion: false });
+
+          return {
+            ok: true,
+            status: 200,
+            async text() {
+              return JSON.stringify({ render_id: "xyz" });
+            },
+          };
+        },
+      });
+
+      const req = createMockReq({
+        method: "POST",
+        query: { render_id: "xyz" },
+        body: { wait_for_completion: false },
+      });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.body, { render_id: "xyz" });
+
+      delete process.env.VSAI_API_KEY;
+    });
+  });
+
+  describe("options", () => {
+    it("proxies the options call", async () => {
+      process.env.VSAI_API_KEY = "options-key";
+      const handler = createOptionsHandler({
+        fetchImpl: async (url, options) => {
+          assert.equal(url, "https://api.virtualstagingai.app/v1/options");
+          assert.equal(options.method, "GET");
+          assert.equal(options.headers.Authorization, "Api-Key options-key");
+
+          return {
+            ok: true,
+            status: 200,
+            async text() {
+              return JSON.stringify({ styles: ["modern"], roomTypes: ["living"] });
+            },
+          };
+        },
+      });
+
+      const req = createMockReq({ method: "GET" });
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.body, { styles: ["modern"], roomTypes: ["living"] });
+
+      delete process.env.VSAI_API_KEY;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated serverless handlers that proxy Wix requests to the Virtual Staging API (ping, render create, status, variations, options) with shared CORS/error helpers
- share reusable HTTP/VSAI utilities and lazily load external dependencies in existing handlers to avoid hard failures when packages are unavailable
- extend the test harness to cover the new endpoints and updated request mocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dd9f827f008330a197327dfe58c4be